### PR TITLE
Do not test for specific Ubuntu patch version

### DIFF
--- a/install
+++ b/install
@@ -13,7 +13,7 @@ if [ -z $GRAPHITE_RELEASE ]; then
     GRAPHITE_RELEASE='0.9.13-pre1'
 fi
 
-if [[ ! $UBUNTU_RELEASE =~ 'Ubuntu 14.04.1 LTS' ]]; then
+if [[ ! $UBUNTU_RELEASE =~ 'Ubuntu 14.04' ]]; then
   echo "Sorry, this is only supported for Ubuntu Linux 14.04."
   exit 1
 fi


### PR DESCRIPTION
Current version of Ubuntu trusty is `14.04.2 LTS` instead of `14.04.1 LTS`, ending the script with an error. This patch checks that the version is at least `14.04`, independently of the patch version.
